### PR TITLE
fix: 壁紙の自動停止判定を安定化

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,10 @@ let package = Package(
             resources: [
                 .process("Resources")
             ]
+        ),
+        .testTarget(
+            name: "LiveWallpaperTests",
+            dependencies: ["LiveWallpaper"]
         )
     ]
 )

--- a/Sources/LiveWallpaper/Components/PlayerView.swift
+++ b/Sources/LiveWallpaper/Components/PlayerView.swift
@@ -26,8 +26,8 @@ final class PlayerView: NSView {
     private func setupLayers() {
         wantsLayer = true
         layer?.masksToBounds = true
-        layer?.backgroundColor = NSColor.black.cgColor
-        playerLayer.backgroundColor = NSColor.black.cgColor
+        layer?.backgroundColor = NSColor.clear.cgColor
+        playerLayer.backgroundColor = NSColor.clear.cgColor
         playerLayer.needsDisplayOnBoundsChange = true
         if playerLayer.superlayer == nil {
             layer?.addSublayer(playerLayer)

--- a/Sources/LiveWallpaper/Core/Models/ForegroundCoverageEngine.swift
+++ b/Sources/LiveWallpaper/Core/Models/ForegroundCoverageEngine.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+struct ForegroundCoverageAppState: Equatable {
+    let pid: pid_t
+    let bundleID: String?
+    let isFinder: Bool
+}
+
+enum ForegroundCoverageProbe: Equatable {
+    case unavailable
+    case uncertain
+    case clear
+    case covered(Set<String>)
+
+    var coveredDisplayIDs: Set<String>? {
+        if case let .covered(displayIDs) = self {
+            return displayIDs
+        }
+        return nil
+    }
+}
+
+struct ForegroundCoverageSnapshot: Equatable {
+    let app: ForegroundCoverageAppState?
+    let targetDisplayIDs: Set<String>
+    let axProbe: ForegroundCoverageProbe
+    let cgProbe: ForegroundCoverageProbe
+}
+
+enum ForegroundCoverageEngine {
+    static func suspendedDisplayIDs(
+        mode: SuspendDetectionMode,
+        snapshot: ForegroundCoverageSnapshot
+    ) -> Set<String> {
+        guard let app = snapshot.app else {
+            return []
+        }
+
+        switch mode {
+        case .frontmostAppPresence:
+            return app.isFinder ? [] : snapshot.targetDisplayIDs
+        case .preciseWindowCoverage:
+            return preciseSuspendedDisplayIDs(app: app, snapshot: snapshot)
+        }
+    }
+
+    private static func preciseSuspendedDisplayIDs(
+        app: ForegroundCoverageAppState,
+        snapshot: ForegroundCoverageSnapshot
+    ) -> Set<String> {
+        if let covered = snapshot.axProbe.coveredDisplayIDs, !covered.isEmpty {
+            return covered
+        }
+        if let covered = snapshot.cgProbe.coveredDisplayIDs {
+            return covered
+        }
+
+        if app.isFinder {
+            return []
+        }
+
+        if snapshot.axProbe == .clear {
+            return []
+        }
+
+        if snapshot.axProbe == .uncertain || snapshot.cgProbe == .uncertain {
+            return snapshot.targetDisplayIDs
+        }
+
+        return []
+    }
+}

--- a/Sources/LiveWallpaper/Core/Models/ForegroundCoverageGeometry.swift
+++ b/Sources/LiveWallpaper/Core/Models/ForegroundCoverageGeometry.swift
@@ -1,0 +1,85 @@
+import CoreGraphics
+import Foundation
+
+struct ForegroundCoverageDisplay: Equatable {
+    let id: String
+    let frames: [CGRect]
+
+    init(id: String, frame: CGRect) {
+        self.id = id
+        self.frames = [frame]
+    }
+
+    init(id: String, frames: [CGRect]) {
+        self.id = id
+        self.frames = frames.filter { !$0.isNull && !$0.isEmpty }
+    }
+}
+
+struct ForegroundCoverageWindow: Equatable {
+    let bounds: CGRect
+    let alpha: Double
+    let layer: Int
+    let isMiniaturized: Bool
+
+    init(
+        bounds: CGRect,
+        alpha: Double = 1,
+        layer: Int = 0,
+        isMiniaturized: Bool = false
+    ) {
+        self.bounds = bounds
+        self.alpha = alpha
+        self.layer = layer
+        self.isMiniaturized = isMiniaturized
+    }
+}
+
+enum ForegroundCoverageGeometry {
+    static func coveredDisplayIDs(
+        by windows: [ForegroundCoverageWindow],
+        displays: [ForegroundCoverageDisplay],
+        minimumWindowSize: CGSize = CGSize(width: 120, height: 120),
+        coverageThreshold: CGFloat
+    ) -> Set<String> {
+        guard !windows.isEmpty, !displays.isEmpty else {
+            return []
+        }
+
+        var covered: Set<String> = []
+        for window in windows where isRelevant(window, minimumWindowSize: minimumWindowSize) {
+            for display in displays {
+                if display.frames.contains(where: { frame in
+                    let intersection = window.bounds.intersection(frame)
+                    guard !intersection.isNull, !intersection.isEmpty else {
+                        return false
+                    }
+                    let area = max(frame.width * frame.height, 1)
+                    let ratio = (intersection.width * intersection.height) / area
+                    return ratio >= coverageThreshold
+                }) {
+                    covered.insert(display.id)
+                }
+            }
+        }
+        return covered
+    }
+
+    private static func isRelevant(
+        _ window: ForegroundCoverageWindow,
+        minimumWindowSize: CGSize
+    ) -> Bool {
+        guard !window.isMiniaturized else {
+            return false
+        }
+        guard window.alpha > 0.01, window.layer >= 0 else {
+            return false
+        }
+        guard window.bounds.width >= minimumWindowSize.width,
+              window.bounds.height >= minimumWindowSize.height
+        else {
+            return false
+        }
+        return true
+    }
+}

--- a/Sources/LiveWallpaper/Core/Models/WallpaperModel+Coverage.swift
+++ b/Sources/LiveWallpaper/Core/Models/WallpaperModel+Coverage.swift
@@ -8,21 +8,47 @@ extension WallpaperModel {
     func setSuspendWhenOtherAppFullScreen(_ enabled: Bool) -> Bool {
         guard suspendWhenOtherAppFullScreen != enabled else {
             if enabled {
-                suspendWhenOtherAppStatusMessage = nil
                 evaluateForegroundCoverageState()
             } else {
-                suspendWhenOtherAppStatusMessage = nil
                 applyCoveringAppSuspension(false)
             }
             return true
         }
 
-        suspendWhenOtherAppStatusMessage = nil
-        suspendWhenOtherAppFullScreen = enabled
         UserDefaults.standard.set(enabled, forKey: "suspendWhenOtherAppFullScreen")
-        configureForegroundCoverageMonitoring()
-        evaluateForegroundCoverageState()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+            guard self.suspendWhenOtherAppFullScreen != enabled else {
+                return
+            }
+            self.suspendWhenOtherAppFullScreen = enabled
+            self.configureForegroundCoverageMonitoring()
+            self.evaluateForegroundCoverageState()
+        }
         return true
+    }
+
+    func setSuspendDetectionMode(_ mode: SuspendDetectionMode) {
+        guard suspendDetectionMode != mode else {
+            evaluateForegroundCoverageState()
+            return
+        }
+
+        UserDefaults.standard.set(mode.rawValue, forKey: "suspendDetectionMode")
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+            guard self.suspendDetectionMode != mode else {
+                return
+            }
+            self.suspendDetectionMode = mode
+            self.refreshAccessibilityTrustForCoverage()
+            self.configureForegroundCoverageMonitoring()
+            self.evaluateForegroundCoverageState()
+        }
     }
 
     func addSuspendExclusionBundleID(_ bundleID: String) {
@@ -68,7 +94,7 @@ extension WallpaperModel {
             return false
         }
         guard let bundle = Bundle(url: resolvedURL),
-              let bundleID = bundle.bundleIdentifier
+            let bundleID = bundle.bundleIdentifier
         else {
             return false
         }
@@ -87,21 +113,29 @@ extension WallpaperModel {
         }
 
         guard suspendWhenOtherAppFullScreen else {
+            refreshAccessibilityTrustForCoverage()
             coverageEvaluationWorkItem?.cancel()
             coverageEvaluationWorkItem = nil
+            activeSpaceTransitionWorkItem?.cancel()
+            activeSpaceTransitionWorkItem = nil
+            activeSpaceCoverageWorkItems.forEach { $0.cancel() }
+            activeSpaceCoverageWorkItems.removeAll()
             removeAXObserver()
             applyCoveringAppSuspension(false)
             return
         }
 
         let workspaceCenter = NSWorkspace.shared.notificationCenter
+        refreshAccessibilityTrustForCoverage()
         frontmostAppObserver = workspaceCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.updateAXObserverForFrontmostApplication()
+                if self?.suspendDetectionMode == .preciseWindowCoverage {
+                    self?.updateAXObserverForFrontmostApplication()
+                }
                 self?.scheduleForegroundCoverageEvaluation()
             }
         }
@@ -112,15 +146,68 @@ extension WallpaperModel {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.scheduleForegroundCoverageEvaluation()
+                self?.handleActiveSpaceDidChange()
             }
         }
 
-        updateAXObserverForFrontmostApplication()
+        if suspendDetectionMode == .preciseWindowCoverage {
+            updateAXObserverForFrontmostApplication()
+        } else {
+            removeAXObserver()
+        }
     }
 
     private func isAccessibilityTrusted() -> Bool {
         AXIsProcessTrusted()
+    }
+
+    @discardableResult
+    func refreshAccessibilityTrustForCoverage() -> Bool {
+        let trusted = isAccessibilityTrusted()
+        guard accessibilityTrustedForCoverage != trusted else {
+            return trusted
+        }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+            guard self.accessibilityTrustedForCoverage != trusted else {
+                return
+            }
+            self.accessibilityTrustedForCoverage = trusted
+        }
+        return trusted
+    }
+
+    func requestAccessibilityPermissionForCoverage() {
+        let options =
+            [
+                kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true
+            ] as CFDictionary
+        _ = AXIsProcessTrustedWithOptions(options)
+
+        if let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        ) {
+            NSWorkspace.shared.open(url)
+        }
+
+        pollAccessibilityPermissionAfterRequest()
+    }
+
+    private func pollAccessibilityPermissionAfterRequest() {
+        for delay in [0.2, 0.8, 1.6, 3.0] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                guard let self else {
+                    return
+                }
+                let trusted = self.refreshAccessibilityTrustForCoverage()
+                if trusted {
+                    self.updateAXObserverForFrontmostApplication()
+                }
+                self.scheduleForegroundCoverageEvaluation()
+            }
+        }
     }
 
     private func ensureAXCoverageObserver() -> ForegroundCoverageAXObserver {
@@ -132,24 +219,13 @@ extension WallpaperModel {
         return observer
     }
 
-    private func updateAccessibilityCoverageStatusMessage(isTrusted: Bool) {
-        if isTrusted {
-            suspendWhenOtherAppStatusMessage = nil
-            return
-        }
-        suspendWhenOtherAppStatusMessage = localizedString(
-            "アクセシビリティ権限が必要です。システム設定でLiveWallpaperを許可してください。"
-        )
-    }
-
     private func updateAXObserverForFrontmostApplication() {
         guard suspendWhenOtherAppFullScreen else {
             removeAXObserver()
             return
         }
 
-        let trusted = isAccessibilityTrusted()
-        updateAccessibilityCoverageStatusMessage(isTrusted: trusted)
+        let trusted = refreshAccessibilityTrustForCoverage()
         guard trusted else {
             removeAXObserver()
             return
@@ -189,11 +265,21 @@ extension WallpaperModel {
         let generation = coverageEvaluationGeneration
         coverageEvaluationWorkItem?.cancel()
         let delay = max(0.2 - elapsed, 0.05)
+        scheduleForegroundCoverageEvaluation(after: delay, generation: generation)
+    }
+
+    private func scheduleForegroundCoverageEvaluation(
+        after delay: TimeInterval,
+        generation: UInt64? = nil
+    ) {
+        coverageEvaluationGeneration &+= generation == nil ? 1 : 0
+        let expectedGeneration = generation ?? coverageEvaluationGeneration
+        coverageEvaluationWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else {
                 return
             }
-            guard generation == coverageEvaluationGeneration else {
+            guard expectedGeneration == coverageEvaluationGeneration else {
                 return
             }
             lastCoverageEvaluationAt = CFAbsoluteTimeGetCurrent()
@@ -201,7 +287,49 @@ extension WallpaperModel {
             coverageEvaluationWorkItem = nil
         }
         coverageEvaluationWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + max(delay, 0.05), execute: workItem)
+    }
+
+    private func handleActiveSpaceDidChange() {
+        guard suspendWhenOtherAppFullScreen, currentVideoPath != nil else {
+            scheduleForegroundCoverageEvaluation()
+            return
+        }
+
+        activeSpaceTransitionWorkItem?.cancel()
+        scheduleActiveSpaceWindowRefresh()
+        scheduleActiveSpaceCoverageEvaluations()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else {
+                return
+            }
+            activeSpaceTransitionWorkItem = nil
+            lastCoverageEvaluationAt = CFAbsoluteTimeGetCurrent()
+            scheduleActiveSpaceWindowRefresh()
+        }
+        activeSpaceTransitionWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.9, execute: workItem)
+    }
+
+    private func scheduleActiveSpaceCoverageEvaluations() {
+        activeSpaceCoverageWorkItems.forEach { $0.cancel() }
+        activeSpaceCoverageWorkItems.removeAll()
+
+        for delay in [0.0, 0.15, 0.45, 0.9] {
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self else {
+                    return
+                }
+                if suspendDetectionMode == .preciseWindowCoverage {
+                    updateAXObserverForFrontmostApplication()
+                }
+                lastCoverageEvaluationAt = CFAbsoluteTimeGetCurrent()
+                evaluateForegroundCoverageState()
+            }
+            activeSpaceCoverageWorkItems.append(workItem)
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        }
     }
 
     func evaluateForegroundCoverageState() {
@@ -214,31 +342,47 @@ extension WallpaperModel {
             return
         }
 
-        let frontmostAppDisplayIDs = displayIDsForFrontmostAppPresence()
-        if !frontmostAppDisplayIDs.isEmpty {
-            applyCoveringAppSuspension(frontmostAppDisplayIDs)
-            return
+        let snapshot = foregroundCoverageSnapshot()
+        if suspendDetectionMode == .frontmostAppPresence {
+            removeAXObserver()
         }
-
-        updateAXObserverForFrontmostApplication()
-        let fullScreenDisplayIDs = fullScreenDisplayIDsByFrontmostApp()
-        let coveredDisplayIDs =
-            fullScreenDisplayIDs.isEmpty ? coveredDisplayIDsByFrontmostApp() : fullScreenDisplayIDs
-        applyCoveringAppSuspension(coveredDisplayIDs)
+        applyCoveringAppSuspension(
+            ForegroundCoverageEngine.suspendedDisplayIDs(
+                mode: suspendDetectionMode,
+                snapshot: snapshot
+            )
+        )
     }
 
-    private func frontmostAppForCoverageEvaluation() -> NSRunningApplication? {
+    private func foregroundCoverageSnapshot() -> ForegroundCoverageSnapshot {
+        let app = frontmostAppStateForCoverageEvaluation()
+        let targetIDs = Set(targetScreens().map { displayIDString(for: $0) })
+
+        guard suspendDetectionMode == .preciseWindowCoverage, let app else {
+            return ForegroundCoverageSnapshot(
+                app: app,
+                targetDisplayIDs: targetIDs,
+                axProbe: .unavailable,
+                cgProbe: .unavailable
+            )
+        }
+
+        return ForegroundCoverageSnapshot(
+            app: app,
+            targetDisplayIDs: targetIDs,
+            axProbe: axCoverageProbe(for: app),
+            cgProbe: cgCoverageProbe(for: app)
+        )
+    }
+
+    private func frontmostAppStateForCoverageEvaluation() -> ForegroundCoverageAppState? {
         guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
             return nil
         }
 
         if let bundleID = frontmostApp.bundleIdentifier,
-           suspendExclusionBundleIDs.contains(normalizeBundleID(bundleID))
+            suspendExclusionBundleIDs.contains(normalizeBundleID(bundleID))
         {
-            return nil
-        }
-
-        if frontmostApp.bundleIdentifier == "com.apple.finder" {
             return nil
         }
 
@@ -248,15 +392,12 @@ extension WallpaperModel {
             return nil
         }
 
-        return frontmostApp
-    }
-
-    private func displayIDsForFrontmostAppPresence() -> Set<String> {
-        guard frontmostAppForCoverageEvaluation() != nil else {
-            return []
-        }
-
-        return Set(targetScreens().map { displayIDString(for: $0) })
+        let bundleID = frontmostApp.bundleIdentifier
+        return ForegroundCoverageAppState(
+            pid: frontmostPID,
+            bundleID: bundleID,
+            isFinder: bundleID == "com.apple.finder"
+        )
     }
 
     private func applyCoveringAppSuspension(_ shouldSuspend: Bool) {
@@ -277,155 +418,159 @@ extension WallpaperModel {
         applySuspensionStateToPlayers()
     }
 
-    private func coveredDisplayIDsByFrontmostApp() -> Set<String> {
-        guard let frontmostApp = frontmostAppForCoverageEvaluation() else {
-            return []
+    private func targetCoverageDisplays() -> [ForegroundCoverageDisplay] {
+        targetScreens().map { screen in
+            let displayID =
+                (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
+                .uint32Value ?? 0
+            var frames = [screen.frame]
+            let quartzFrame = CGDisplayBounds(displayID)
+            if !quartzFrame.isNull, !quartzFrame.isEmpty, quartzFrame != screen.frame {
+                frames.append(quartzFrame)
+            }
+            return ForegroundCoverageDisplay(
+                id: displayIDString(for: screen),
+                frames: frames
+            )
         }
+    }
 
+    private func cgCoverageProbe(for app: ForegroundCoverageAppState) -> ForegroundCoverageProbe {
         guard
             let windowInfo = CGWindowListCopyWindowInfo(
                 [.optionOnScreenOnly, .excludeDesktopElements],
                 kCGNullWindowID
             ) as? [[String: Any]]
         else {
-            return []
+            return .uncertain
         }
 
-        let frontmostPID = frontmostApp.processIdentifier
-
-        let screenInfos = targetScreens().map { screen in
-            (
-                id: displayIDString(for: screen),
-                frame: screen.frame,
-                area: max(screen.frame.width * screen.frame.height, 1)
-            )
-        }
-        guard !screenInfos.isEmpty else {
-            return []
+        let displays = targetCoverageDisplays()
+        guard !displays.isEmpty else {
+            return .clear
         }
 
-        var covered: Set<String> = []
+        var windows: [ForegroundCoverageWindow] = []
+        var sawRestrictedFrontmostWindow = false
 
         for info in windowInfo {
             let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value
-            guard ownerPID == frontmostPID else {
+            guard ownerPID == app.pid else {
                 continue
             }
 
             let alpha = (info[kCGWindowAlpha as String] as? NSNumber)?.doubleValue ?? 1
-            if alpha <= 0.01 {
-                continue
-            }
-
             let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
-            if layer < 0 {
-                continue
-            }
-
             guard
                 let boundsDictionary = info[kCGWindowBounds as String] as? NSDictionary,
                 let bounds = CGRect(dictionaryRepresentation: boundsDictionary)
             else {
+                sawRestrictedFrontmostWindow = true
                 continue
             }
 
-            guard bounds.width >= 120, bounds.height >= 120 else {
-                continue
-            }
-
-            for screen in screenInfos {
-                let intersection = bounds.intersection(screen.frame)
-                guard !intersection.isNull, !intersection.isEmpty else {
-                    continue
-                }
-                let intersectionArea = intersection.width * intersection.height
-                let coveredRatio = intersectionArea / screen.area
-                if coveredRatio >= 0.9 {
-                    covered.insert(screen.id)
-                }
-            }
+            windows.append(
+                ForegroundCoverageWindow(
+                    bounds: bounds,
+                    alpha: alpha,
+                    layer: layer
+                )
+            )
         }
 
-        return covered
+        guard !sawRestrictedFrontmostWindow else {
+            return .uncertain
+        }
+        guard !windows.isEmpty else {
+            return app.isFinder ? .clear : .uncertain
+        }
+
+        let covered = ForegroundCoverageGeometry.coveredDisplayIDs(
+            by: windows,
+            displays: displays,
+            coverageThreshold: 0.9
+        )
+        return covered.isEmpty ? .clear : .covered(covered)
     }
 
-    private func fullScreenDisplayIDsByFrontmostApp() -> Set<String> {
-        guard let frontmostApp = frontmostAppForCoverageEvaluation() else {
-            return []
+    private func axCoverageProbe(for app: ForegroundCoverageAppState) -> ForegroundCoverageProbe {
+        guard isAccessibilityTrusted() else {
+            return .uncertain
         }
 
-        let frontmostPID = frontmostApp.processIdentifier
+        guard let windowElement = frontmostAXWindowElement(for: app.pid) else {
+            return app.isFinder ? .clear : .uncertain
+        }
 
-        let appElement = AXUIElementCreateApplication(frontmostPID)
+        guard let bounds = boundsForAXWindow(windowElement) else {
+            return .uncertain
+        }
+
+        let isMiniaturized =
+            boolAXAttribute(
+                kAXMinimizedAttribute as CFString,
+                in: windowElement
+            ) ?? false
+        let isFullScreen =
+            boolAXAttribute(
+                "AXFullScreen" as CFString,
+                in: windowElement
+            ) ?? false
+        let threshold: CGFloat = isFullScreen ? 0.95 : 0.9
+
+        let displays = targetCoverageDisplays()
+        guard !displays.isEmpty else {
+            return .clear
+        }
+
+        let covered = ForegroundCoverageGeometry.coveredDisplayIDs(
+            by: [
+                ForegroundCoverageWindow(
+                    bounds: bounds,
+                    isMiniaturized: isMiniaturized
+                )
+            ],
+            displays: displays,
+            coverageThreshold: threshold
+        )
+        if isFullScreen, covered.isEmpty {
+            return .uncertain
+        }
+        return covered.isEmpty ? .clear : .covered(covered)
+    }
+
+    private func frontmostAXWindowElement(for pid: pid_t) -> AXUIElement? {
+        let appElement = AXUIElementCreateApplication(pid)
         var focusedWindow: CFTypeRef?
         let focusedResult = AXUIElementCopyAttributeValue(
             appElement,
             kAXFocusedWindowAttribute as CFString,
             &focusedWindow
         )
-        if focusedResult != .success {
-            var mainWindow: CFTypeRef?
-            let mainResult = AXUIElementCopyAttributeValue(
-                appElement,
-                kAXMainWindowAttribute as CFString,
-                &mainWindow
-            )
-            if mainResult == .success {
-                focusedWindow = mainWindow
-            }
+        if focusedResult == .success, let focusedWindow {
+            return unsafeBitCast(focusedWindow, to: AXUIElement.self)
         }
 
-        guard let windowRef = focusedWindow else {
-            return []
-        }
-        let windowElement = unsafeBitCast(windowRef, to: AXUIElement.self)
-
-        var fullScreenValue: CFTypeRef?
-        let fullScreenAttribute: CFString = "AXFullScreen" as CFString
-        let fullScreenResult = AXUIElementCopyAttributeValue(
-            windowElement,
-            fullScreenAttribute,
-            &fullScreenValue
+        var mainWindow: CFTypeRef?
+        let mainResult = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXMainWindowAttribute as CFString,
+            &mainWindow
         )
-        guard fullScreenResult == .success,
-              let number = fullScreenValue as? NSNumber,
-              number.boolValue
-        else {
-            return []
+        if mainResult == .success, let mainWindow {
+            return unsafeBitCast(mainWindow, to: AXUIElement.self)
         }
 
-        guard let bounds = boundsForAXWindow(windowElement) else {
-            return coveredDisplayIDsByFrontmostApp()
-        }
+        return nil
+    }
 
-        let screenInfos = targetScreens().map { screen in
-            (
-                id: displayIDString(for: screen),
-                frame: screen.frame,
-                area: max(screen.frame.width * screen.frame.height, 1)
-            )
+    private func boolAXAttribute(_ attribute: CFString, in element: AXUIElement) -> Bool? {
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(element, attribute, &value)
+        guard result == .success else {
+            return nil
         }
-        guard !screenInfos.isEmpty else {
-            return []
-        }
-
-        var covered: Set<String> = []
-        for screen in screenInfos {
-            let intersection = bounds.intersection(screen.frame)
-            guard !intersection.isNull, !intersection.isEmpty else {
-                continue
-            }
-            let coveredRatio = (intersection.width * intersection.height) / screen.area
-            if coveredRatio >= 0.95 {
-                covered.insert(screen.id)
-            }
-        }
-
-        if !covered.isEmpty {
-            return covered
-        }
-
-        return coveredDisplayIDsByFrontmostApp()
+        return (value as? NSNumber)?.boolValue
     }
 
     private func boundsForAXWindow(_ windowElement: AXUIElement) -> CGRect? {
@@ -444,11 +589,11 @@ extension WallpaperModel {
         )
 
         guard positionResult == .success,
-              sizeResult == .success,
-              let positionValue,
-              let sizeValue,
-              CFGetTypeID(positionValue) == AXValueGetTypeID(),
-              CFGetTypeID(sizeValue) == AXValueGetTypeID()
+            sizeResult == .success,
+            let positionValue,
+            let sizeValue,
+            CFGetTypeID(positionValue) == AXValueGetTypeID(),
+            CFGetTypeID(sizeValue) == AXValueGetTypeID()
         else {
             return nil
         }
@@ -459,9 +604,9 @@ extension WallpaperModel {
         var point = CGPoint.zero
         var size = CGSize.zero
         guard AXValueGetType(axPosition) == .cgPoint,
-              AXValueGetType(axSize) == .cgSize,
-              AXValueGetValue(axPosition, .cgPoint, &point),
-              AXValueGetValue(axSize, .cgSize, &size)
+            AXValueGetType(axSize) == .cgSize,
+            AXValueGetValue(axPosition, .cgPoint, &point),
+            AXValueGetValue(axSize, .cgSize, &size)
         else {
             return nil
         }

--- a/Sources/LiveWallpaper/Core/Models/WallpaperModel+Persistence.swift
+++ b/Sources/LiveWallpaper/Core/Models/WallpaperModel+Persistence.swift
@@ -57,6 +57,13 @@ extension WallpaperModel {
         applyLightweightSettings()
         suspendWhenOtherAppFullScreen =
             UserDefaults.standard.object(forKey: "suspendWhenOtherAppFullScreen") as? Bool ?? false
+        if let detectionModeValue = UserDefaults.standard.string(
+            forKey: "suspendDetectionMode"
+        ),
+            let restoredDetectionMode = SuspendDetectionMode(rawValue: detectionModeValue)
+        {
+            suspendDetectionMode = restoredDetectionMode
+        }
         if let savedExclusions = UserDefaults.standard.stringArray(
             forKey: "suspendExclusionBundleIDs"
         ) {
@@ -65,8 +72,6 @@ extension WallpaperModel {
             )
             .sorted()
         }
-        suspendWhenOtherAppStatusMessage = nil
-
         if let playlistData = UserDefaults.standard.data(forKey: "playlistsData"),
            let decoded = try? JSONDecoder().decode([WallpaperPlaylist].self, from: playlistData)
         {
@@ -222,9 +227,9 @@ extension WallpaperModel {
         setFullScreenAuxiliary(false)
         setAdvancedSharingEnabled(false)
         _ = setSuspendWhenOtherAppFullScreen(false)
+        setSuspendDetectionMode(.frontmostAppPresence)
         suspendExclusionBundleIDs = []
         UserDefaults.standard.removeObject(forKey: "suspendExclusionBundleIDs")
-        suspendWhenOtherAppStatusMessage = nil
         startAutoFrameRateMonitoring()
     }
 }

--- a/Sources/LiveWallpaper/Core/Models/WallpaperModel+Windowing.swift
+++ b/Sources/LiveWallpaper/Core/Models/WallpaperModel+Windowing.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AVFoundation
 import Foundation
 
 @MainActor
@@ -18,27 +19,51 @@ extension WallpaperModel {
         guard displayMode != mode else {
             return
         }
-        displayMode = mode
         UserDefaults.standard.set(mode.rawValue, forKey: "displayMode")
-        scheduleWindowRebuild()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+            guard self.displayMode != mode else {
+                return
+            }
+            self.displayMode = mode
+            self.scheduleWindowRebuild()
+        }
     }
 
     func setDesktopLevelOffset(_ offset: DesktopLevelOffset) {
         guard desktopLevelOffset != offset else {
             return
         }
-        desktopLevelOffset = offset
         UserDefaults.standard.set(offset.rawValue, forKey: "desktopLevelOffset")
-        scheduleWindowOptionsApply()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+            guard self.desktopLevelOffset != offset else {
+                return
+            }
+            self.desktopLevelOffset = offset
+            self.scheduleWindowOptionsApply()
+        }
     }
 
     func setFullScreenAuxiliary(_ enabled: Bool) {
         guard useFullScreenAuxiliary != enabled else {
             return
         }
-        useFullScreenAuxiliary = enabled
         UserDefaults.standard.set(enabled, forKey: "useFullScreenAuxiliary")
-        scheduleWindowOptionsApply()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+            guard self.useFullScreenAuxiliary != enabled else {
+                return
+            }
+            self.useFullScreenAuxiliary = enabled
+            self.scheduleWindowOptionsApply()
+        }
     }
 
     func availableDisplayScreens() -> [DisplayScreenInfo] {
@@ -56,6 +81,12 @@ extension WallpaperModel {
     }
 
     private func displayIDForWindow(at index: Int) -> String {
+        if index < windows.count {
+            let window = windows[index]
+            if let displayID = displayIDByWindow[ObjectIdentifier(window)] {
+                return displayID
+            }
+        }
         if index < windows.count, let screen = windows[index].screen {
             return displayIDString(for: screen)
         }
@@ -103,65 +134,57 @@ extension WallpaperModel {
         let screens: [NSScreen] = targetScreens()
         let player = ensureSharedPlayer()
 
-        if windows.count > screens.count {
-            let extras = Array(windows[screens.count...])
-            for window in extras {
-                prepareWindowForRetire(window)
-                window.orderOut(nil)
+        var reusableByDisplayID: [String: (window: NSWindow, playerView: PlayerView)] = [:]
+        for index in windows.indices where index < playerViews.count {
+            let displayID = displayIDForWindow(at: index)
+            if reusableByDisplayID[displayID] == nil {
+                reusableByDisplayID[displayID] = (windows[index], playerViews[index])
             }
-            windows.removeLast(windows.count - screens.count)
-            playerViews.removeLast(playerViews.count - screens.count)
-            retireWindows(extras)
         }
 
-        for (index, screen) in screens.enumerated() {
-            if index < windows.count {
-                let window = windows[index]
-                let playerView = playerViews[index]
+        var nextWindows: [NSWindow] = []
+        var nextPlayerViews: [PlayerView] = []
+        var reusedWindowIDs: Set<ObjectIdentifier> = []
 
-                applyWindowOptions(window)
-                window.ignoresMouseEvents = clickThrough
-                if window.frame != screen.frame {
-                    window.setFrame(screen.frame, display: true)
-                }
-                applyPlayerPresentation(to: playerView, screen: screen)
-                if playerView.playerLayer.player !== player {
-                    playerView.playerLayer.player = player
-                }
-                if window.contentView !== playerView {
-                    window.contentView = playerView
-                }
-                window.orderBack(nil)
-                window.orderFront(nil)
-                continue
-            }
-
-            let frame: NSRect = screen.frame
-            let window = NSWindow(
-                contentRect: frame,
-                styleMask: [.borderless],
-                backing: .buffered,
-                defer: false
+        for screen in screens {
+            let displayID = displayIDString(for: screen)
+            let pair = reusableByDisplayID[displayID] ?? makeWallpaperWindow(
+                for: screen,
+                player: player
             )
+            let window = pair.window
+            let playerView = pair.playerView
 
             applyWindowOptions(window)
-            window.backgroundColor = .clear
-            window.isOpaque = false
-            window.hasShadow = false
             window.ignoresMouseEvents = clickThrough
-            window.setFrame(frame, display: true)
-
-            let playerView = PlayerView(frame: CGRect(origin: .zero, size: frame.size))
-            playerView.autoresizingMask = [.width, .height]
+            if window.frame != screen.frame {
+                window.setFrame(screen.frame, display: true)
+            }
             applyPlayerPresentation(to: playerView, screen: screen)
-            playerView.playerLayer.player = player
-            window.contentView = playerView
+            if playerView.playerLayer.player !== player {
+                playerView.playerLayer.player = player
+            }
+            if window.contentView !== playerView {
+                window.contentView = playerView
+            }
             window.orderBack(nil)
             window.orderFront(nil)
 
-            windows.append(window)
-            playerViews.append(playerView)
+            displayIDByWindow[ObjectIdentifier(window)] = displayID
+            reusedWindowIDs.insert(ObjectIdentifier(window))
+            nextWindows.append(window)
+            nextPlayerViews.append(playerView)
         }
+
+        let obsoleteWindows = windows.filter { !reusedWindowIDs.contains(ObjectIdentifier($0)) }
+        for window in obsoleteWindows {
+            prepareWindowForRetire(window)
+            window.orderOut(nil)
+        }
+        retireWindows(obsoleteWindows)
+
+        windows = nextWindows
+        playerViews = nextPlayerViews
 
         let validDisplayIDs = Set(screens.map { displayIDString(for: $0) })
         suspendedDisplayIDs = suspendedDisplayIDs.intersection(validDisplayIDs)
@@ -170,7 +193,32 @@ extension WallpaperModel {
         lastScreenSignatures = screenSignatures(for: screens)
     }
 
+    private func makeWallpaperWindow(
+        for screen: NSScreen,
+        player: AVQueuePlayer
+    ) -> (window: NSWindow, playerView: PlayerView) {
+        let frame: NSRect = screen.frame
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.backgroundColor = .clear
+        window.isOpaque = false
+        window.hasShadow = false
+        window.setFrame(frame, display: true)
+
+        let playerView = PlayerView(frame: CGRect(origin: .zero, size: frame.size))
+        playerView.autoresizingMask = [.width, .height]
+        playerView.playerLayer.player = player
+        window.contentView = playerView
+        return (window, playerView)
+    }
+
     private func prepareWindowForRetire(_ window: NSWindow) {
+        displayIDByWindow.removeValue(forKey: ObjectIdentifier(window))
         if let playerView = window.contentView as? PlayerView {
             presentationCacheByPlayerView.removeValue(forKey: ObjectIdentifier(playerView))
             playerView.playerLayer.player = nil
@@ -215,6 +263,50 @@ extension WallpaperModel {
         window.collectionBehavior = behavior
     }
 
+    func scheduleActiveSpaceWindowRefresh() {
+        activeSpaceWindowRefreshWorkItems.forEach { $0.cancel() }
+        activeSpaceWindowRefreshWorkItems.removeAll()
+
+        for delay in [0.03, 0.18, 0.45] {
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self else {
+                    return
+                }
+                refreshWallpaperWindowsForActiveSpace()
+            }
+            activeSpaceWindowRefreshWorkItems.append(workItem)
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        }
+    }
+
+    private func refreshWallpaperWindowsForActiveSpace() {
+        let screensByID = Dictionary(
+            uniqueKeysWithValues: targetScreens().map { (displayIDString(for: $0), $0) }
+        )
+
+        for (index, window) in windows.enumerated() {
+            applyWindowOptions(window)
+            window.ignoresMouseEvents = clickThrough
+            let displayID = displayIDForWindow(at: index)
+            if let screen = screensByID[displayID] {
+                if window.frame != screen.frame {
+                    window.setFrame(screen.frame, display: true)
+                }
+                if index < playerViews.count {
+                    let playerView = playerViews[index]
+                    applyPlayerPresentation(to: playerView, screen: screen)
+                    if playerView.playerLayer.player !== sharedPlayer {
+                        playerView.playerLayer.player = sharedPlayer
+                    }
+                    if window.contentView !== playerView {
+                        window.contentView = playerView
+                    }
+                }
+            }
+            window.orderFrontRegardless()
+        }
+    }
+
     func scheduleScreenSync() {
         screenChangeWorkItem?.cancel()
 
@@ -234,17 +326,6 @@ extension WallpaperModel {
         let signatures = screenSignatures(for: screens)
 
         guard signatures != lastScreenSignatures else {
-            return
-        }
-
-        if screens.count == windows.count {
-            for (index, screen) in screens.enumerated() {
-                if windows[index].frame != screen.frame {
-                    windows[index].setFrame(screen.frame, display: true)
-                }
-                applyPlayerPresentation(to: playerViews[index], screen: screen)
-            }
-            lastScreenSignatures = signatures
             return
         }
 

--- a/Sources/LiveWallpaper/Core/Models/WallpaperModel.swift
+++ b/Sources/LiveWallpaper/Core/Models/WallpaperModel.swift
@@ -59,6 +59,9 @@ final class WallpaperModel: ObservableObject {
     var windowOptionsWorkItem: DispatchWorkItem?
     var windowRetireWorkItem: DispatchWorkItem?
     var retiredWindows: [NSWindow] = []
+    var displayIDByWindow: [ObjectIdentifier: String] = [:]
+    var activeSpaceWindowRefreshWorkItems: [DispatchWorkItem] = []
+    var activeSpaceCoverageWorkItems: [DispatchWorkItem] = []
     var lastScreenSignatures: [ScreenSignature] = []
     var frontmostAppObserver: NSObjectProtocol?
     var activeSpaceObserver: NSObjectProtocol?
@@ -69,6 +72,7 @@ final class WallpaperModel: ObservableObject {
     var autoFrameRateBitRateFactor: Double = 1.0
     var autoFrameRateBufferAdjustment: TimeInterval = 0
     var coverageEvaluationWorkItem: DispatchWorkItem?
+    var activeSpaceTransitionWorkItem: DispatchWorkItem?
     var coverageEvaluationGeneration: UInt64 = 0
     var statePersistWorkItem: DispatchWorkItem?
     var persistenceFailureCount: Int = 0
@@ -97,8 +101,9 @@ final class WallpaperModel: ObservableObject {
     @Published var desktopLevelOffset: DesktopLevelOffset = .zero
     @Published var useFullScreenAuxiliary: Bool = false
     @Published var suspendWhenOtherAppFullScreen: Bool = false
+    @Published var suspendDetectionMode: SuspendDetectionMode = .frontmostAppPresence
+    @Published var accessibilityTrustedForCoverage: Bool = false
     @Published var suspendExclusionBundleIDs: [String] = []
-    @Published var suspendWhenOtherAppStatusMessage: String?
     @Published var persistenceFailureMessage: String?
 
     @Published var playlists: [WallpaperPlaylist] = []
@@ -174,6 +179,7 @@ final class WallpaperModel: ObservableObject {
         configurePlayer()
         restoreState()
         LocalizationManager.setLanguage(effectiveAppLanguageCode)
+        refreshAccessibilityTrustForCoverage()
         rebuildWindows()
         if let savedPath: String = currentVideoPath {
             playVideo(url: URL(fileURLWithPath: savedPath))
@@ -197,7 +203,12 @@ final class WallpaperModel: ObservableObject {
         windowRebuildWorkItem?.cancel()
         windowOptionsWorkItem?.cancel()
         windowRetireWorkItem?.cancel()
+        activeSpaceWindowRefreshWorkItems.forEach { $0.cancel() }
+        activeSpaceWindowRefreshWorkItems.removeAll()
+        activeSpaceCoverageWorkItems.forEach { $0.cancel() }
+        activeSpaceCoverageWorkItems.removeAll()
         coverageEvaluationWorkItem?.cancel()
+        activeSpaceTransitionWorkItem?.cancel()
         statePersistWorkItem?.cancel()
         retiredWindows.removeAll()
         if let observer: any NSObjectProtocol = screenChangeObserver {

--- a/Sources/LiveWallpaper/Core/Models/WallpaperTypes.swift
+++ b/Sources/LiveWallpaper/Core/Models/WallpaperTypes.swift
@@ -3,6 +3,11 @@ enum DisplayMode: String {
     case allScreens
 }
 
+enum SuspendDetectionMode: String {
+    case frontmostAppPresence
+    case preciseWindowCoverage
+}
+
 enum VideoFitMode: String, Codable {
     case fill
     case fit

--- a/Sources/LiveWallpaper/Core/Services/ForegroundCoverageAXObserver.swift
+++ b/Sources/LiveWallpaper/Core/Services/ForegroundCoverageAXObserver.swift
@@ -19,11 +19,18 @@ final class ForegroundCoverageAXObserver {
         }
     }
 
-    private static let notificationNames: [CFString] = [
+    private static let requiredNotificationNames: [CFString] = [
         kAXFocusedWindowChangedNotification as CFString,
         kAXWindowMovedNotification as CFString,
         kAXWindowResizedNotification as CFString,
         kAXMainWindowChangedNotification as CFString
+    ]
+
+    private static let optionalNotificationNames: [CFString] = [
+        kAXWindowCreatedNotification as CFString,
+        kAXWindowMiniaturizedNotification as CFString,
+        kAXWindowDeminiaturizedNotification as CFString,
+        kAXUIElementDestroyedNotification as CFString
     ]
 
     private static let axCallback: AXObserverCallback = { _, _, _, refcon in
@@ -80,12 +87,15 @@ final class ForegroundCoverageAXObserver {
 
         let appElement = AXUIElementCreateApplication(pid)
 
-        for notification in Self.notificationNames {
+        for notification in Self.requiredNotificationNames {
             let addResult = AXObserverAddNotification(observer, appElement, notification, refcon)
             if addResult != .success {
                 detach()
                 return false
             }
+        }
+        for notification in Self.optionalNotificationNames {
+            _ = AXObserverAddNotification(observer, appElement, notification, refcon)
         }
 
         CFRunLoopAddSource(
@@ -111,7 +121,7 @@ final class ForegroundCoverageAXObserver {
         }
 
         if let appElement = observedAppElement {
-            for notification in Self.notificationNames {
+            for notification in Self.requiredNotificationNames + Self.optionalNotificationNames {
                 _ = AXObserverRemoveNotification(observer, appElement, notification)
             }
         }

--- a/Sources/LiveWallpaper/Features/Settings/Components/FitEditorPreview.swift
+++ b/Sources/LiveWallpaper/Features/Settings/Components/FitEditorPreview.swift
@@ -114,10 +114,14 @@ extension SettingsView {
             }
             .contentShape(RoundedRectangle(cornerRadius: 12))
             .onAppear {
-                updateFitEditorPreviewFrameSize(frameSize, path: path, screenID: screenID)
+                DispatchQueue.main.async {
+                    updateFitEditorPreviewFrameSize(frameSize, path: path, screenID: screenID)
+                }
             }
             .onChange(of: frameSize) { newSize in
-                updateFitEditorPreviewFrameSize(newSize, path: path, screenID: screenID)
+                DispatchQueue.main.async {
+                    updateFitEditorPreviewFrameSize(newSize, path: path, screenID: screenID)
+                }
             }
         }
         .frame(maxWidth: .infinity)

--- a/Sources/LiveWallpaper/Features/Settings/Sections/DisplaySection.swift
+++ b/Sources/LiveWallpaper/Features/Settings/Sections/DisplaySection.swift
@@ -29,20 +29,72 @@ extension SettingsView {
       }
 
       Toggle(model.localizedString("再生の軽量モード（省電力）"), isOn: lightweightModeBinding)
-      Toggle(model.localizedString("他のアプリが前面にあるとき再生を停止"), isOn: suspendWhenFullScreenBinding)
-
-      if let statusMessage = model.suspendWhenOtherAppStatusMessage {
-        Text(statusMessage)
-          .font(.caption)
-          .foregroundColor(.secondary)
-      }
+      Toggle(model.localizedString("作業中は壁紙の再生を自動停止"), isOn: suspendWhenFullScreenBinding)
 
       if model.suspendWhenOtherAppFullScreen {
+        suspendDetectionModeSection
         suspendExclusionSection
       }
 
       advancedSettingsSection
     }
+  }
+
+  var suspendDetectionModeSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 16) {
+        Text(model.localizedString("停止判定"))
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .frame(width: 130, alignment: .leading)
+        Picker("", selection: suspendDetectionModeBinding) {
+          Text(model.localizedString("前面アプリ")).tag(SuspendDetectionMode.frontmostAppPresence)
+          Text(model.localizedString("画面を覆う時")).tag(SuspendDetectionMode.preciseWindowCoverage)
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(width: 240, alignment: .leading)
+      }
+
+      Text(suspendDetectionModeDescription())
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+
+      if shouldShowAccessibilityCoverageWarning {
+        VStack(alignment: .leading, spacing: 6) {
+          Text(accessibilityCoverageWarningText())
+            .font(.caption)
+            .foregroundColor(.red)
+            .frame(maxWidth: .infinity, alignment: .leading)
+          Button(model.localizedString("アクセシビリティ許可を開く")) {
+            model.requestAccessibilityPermissionForCoverage()
+          }
+          .buttonStyle(.borderedProminent)
+          .controlSize(.small)
+        }
+      }
+    }
+    .padding(.vertical, 6)
+  }
+
+  func suspendDetectionModeDescription() -> String {
+    switch model.suspendDetectionMode {
+    case .frontmostAppPresence:
+      return model.localizedString("Screen Recording権限を使わず、他のアプリが前面にある間は対象ディスプレイの再生を止めます。")
+    case .preciseWindowCoverage:
+      return model.localizedString("アクセシビリティ権限がある場合、前面ウィンドウが画面を大きく覆う時だけ停止します。判定できない時は安全側として停止します。")
+    }
+  }
+
+  var shouldShowAccessibilityCoverageWarning: Bool {
+    model.suspendWhenOtherAppFullScreen
+      && model.suspendDetectionMode == .preciseWindowCoverage
+      && !model.accessibilityTrustedForCoverage
+  }
+
+  func accessibilityCoverageWarningText() -> String {
+    model.localizedString("精密な停止判定にはアクセシビリティ権限が必要です。許可されるまでは安全側として前面アプリがある画面を停止します。")
   }
 
   var suspendExclusionSection: some View {

--- a/Sources/LiveWallpaper/Features/Settings/SettingsBindings.swift
+++ b/Sources/LiveWallpaper/Features/Settings/SettingsBindings.swift
@@ -57,6 +57,13 @@ extension SettingsView {
     )
   }
 
+  var suspendDetectionModeBinding: Binding<SuspendDetectionMode> {
+    Binding(
+      get: { model.suspendDetectionMode },
+      set: { model.setSuspendDetectionMode($0) }
+    )
+  }
+
   var qualityPresetBinding: Binding<QualityPreset> {
     Binding(
       get: { model.qualityPreset },

--- a/Sources/LiveWallpaper/Features/Settings/SettingsView.swift
+++ b/Sources/LiveWallpaper/Features/Settings/SettingsView.swift
@@ -165,6 +165,9 @@ struct SettingsView: View {
             .onReceive(NotificationCenter.default.publisher(for: .thumbnailCacheDidClear)) { _ in
                 thumbnailCache.clear()
             }
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+                model.refreshAccessibilityTrustForCoverage()
+            }
             .onChange(of: selectedTab) { tab in
                 if tab == .wallpaperFit {
                     ensureFitEditorScreenSelection()
@@ -198,6 +201,7 @@ struct SettingsView: View {
                 syncVolumeInputWithModel()
                 pruneMissingWallpaperThumbnails()
                 requestCurrentWallpaperThumbnailIfNeeded()
+                model.refreshAccessibilityTrustForCoverage()
                 thumbnailCache.prewarm(paths: Array(model.allRegisteredVideoPaths.prefix(10)))
                 processThumbnailQueue()
                 ensureFitEditorScreenSelection()

--- a/Sources/LiveWallpaper/Features/Settings/Support/MediaLibrary.swift
+++ b/Sources/LiveWallpaper/Features/Settings/Support/MediaLibrary.swift
@@ -265,20 +265,46 @@ extension SettingsView {
             return
         }
         guard let path = resolvedFitEditorVideoPath(), !path.isEmpty else {
-            fitEditorDraftPath = ""
-            fitEditorDraftScreenID = ""
+            clearFitEditorDraft()
             return
         }
         loadFitEditorDraft(path: path, screenID: resolvedFitScreenID())
     }
 
     func loadFitEditorDraft(path: String, screenID: String) {
+        let fitMode = model.wallpaperFitMode(path: path, screenID: screenID)
+        let zoom = model.wallpaperZoom(path: path, screenID: screenID)
+        let offsetX = model.wallpaperOffsetX(path: path, screenID: screenID)
+        let offsetY = model.wallpaperOffsetY(path: path, screenID: screenID)
+
+        guard fitEditorDraftPath != path
+            || fitEditorDraftScreenID != screenID
+            || fitEditorDraftFitMode != fitMode
+            || fitEditorDraftZoom != zoom
+            || fitEditorDraftOffsetX != offsetX
+            || fitEditorDraftOffsetY != offsetY
+        else {
+            return
+        }
+
         fitEditorDraftPath = path
         fitEditorDraftScreenID = screenID
-        fitEditorDraftFitMode = model.wallpaperFitMode(path: path, screenID: screenID)
-        fitEditorDraftZoom = model.wallpaperZoom(path: path, screenID: screenID)
-        fitEditorDraftOffsetX = model.wallpaperOffsetX(path: path, screenID: screenID)
-        fitEditorDraftOffsetY = model.wallpaperOffsetY(path: path, screenID: screenID)
+        fitEditorDraftFitMode = fitMode
+        fitEditorDraftZoom = zoom
+        fitEditorDraftOffsetX = offsetX
+        fitEditorDraftOffsetY = offsetY
+    }
+
+    func clearFitEditorDraft() {
+        guard !fitEditorDraftPath.isEmpty || !fitEditorDraftScreenID.isEmpty else {
+            return
+        }
+        fitEditorDraftPath = ""
+        fitEditorDraftScreenID = ""
+        fitEditorDraftFitMode = .fill
+        fitEditorDraftZoom = 1.0
+        fitEditorDraftOffsetX = 0.0
+        fitEditorDraftOffsetY = 0.0
     }
 
     func ensureFitEditorDraft(path: String, screenID: String) {
@@ -289,22 +315,30 @@ extension SettingsView {
     }
 
     func fitEditorFitMode(path: String, screenID: String) -> VideoFitMode {
-        ensureFitEditorDraft(path: path, screenID: screenID)
+        guard fitEditorDraftPath == path, fitEditorDraftScreenID == screenID else {
+            return model.wallpaperFitMode(path: path, screenID: screenID)
+        }
         return fitEditorDraftFitMode
     }
 
     func fitEditorZoom(path: String, screenID: String) -> Double {
-        ensureFitEditorDraft(path: path, screenID: screenID)
+        guard fitEditorDraftPath == path, fitEditorDraftScreenID == screenID else {
+            return model.wallpaperZoom(path: path, screenID: screenID)
+        }
         return fitEditorDraftZoom
     }
 
     func fitEditorOffsetX(path: String, screenID: String) -> Double {
-        ensureFitEditorDraft(path: path, screenID: screenID)
+        guard fitEditorDraftPath == path, fitEditorDraftScreenID == screenID else {
+            return model.wallpaperOffsetX(path: path, screenID: screenID)
+        }
         return fitEditorDraftOffsetX
     }
 
     func fitEditorOffsetY(path: String, screenID: String) -> Double {
-        ensureFitEditorDraft(path: path, screenID: screenID)
+        guard fitEditorDraftPath == path, fitEditorDraftScreenID == screenID else {
+            return model.wallpaperOffsetY(path: path, screenID: screenID)
+        }
         return fitEditorDraftOffsetY
     }
 
@@ -340,6 +374,9 @@ extension SettingsView {
     }
 
     func updateFitEditorPreviewFrameSize(_ frameSize: CGSize, path: String, screenID: String) {
+        guard fitEditorPreviewFrameSize != frameSize else {
+            return
+        }
         fitEditorPreviewFrameSize = frameSize
         guard fitEditorDraftPath == path, fitEditorDraftScreenID == screenID else {
             return

--- a/Tests/LiveWallpaperTests/ForegroundCoverageEngineTests.swift
+++ b/Tests/LiveWallpaperTests/ForegroundCoverageEngineTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import LiveWallpaper
+
+final class ForegroundCoverageEngineTests: XCTestCase {
+    private let targetIDs: Set<String> = ["main"]
+
+    func testFrontmostModeIgnoresFinderDesktop() {
+        let snapshot = ForegroundCoverageSnapshot(
+            app: ForegroundCoverageAppState(
+                pid: 100,
+                bundleID: "com.apple.finder",
+                isFinder: true
+            ),
+            targetDisplayIDs: targetIDs,
+            axProbe: .unavailable,
+            cgProbe: .unavailable
+        )
+
+        let suspended = ForegroundCoverageEngine.suspendedDisplayIDs(
+            mode: .frontmostAppPresence,
+            snapshot: snapshot
+        )
+
+        XCTAssertTrue(suspended.isEmpty)
+    }
+
+    func testPreciseModeStopsForFinderWindowCoverage() {
+        let snapshot = ForegroundCoverageSnapshot(
+            app: ForegroundCoverageAppState(
+                pid: 100,
+                bundleID: "com.apple.finder",
+                isFinder: true
+            ),
+            targetDisplayIDs: targetIDs,
+            axProbe: .clear,
+            cgProbe: .covered(["main"])
+        )
+
+        let suspended = ForegroundCoverageEngine.suspendedDisplayIDs(
+            mode: .preciseWindowCoverage,
+            snapshot: snapshot
+        )
+
+        XCTAssertEqual(suspended, ["main"])
+    }
+
+    func testPreciseModeFallsBackWhenNonFinderIsUncertain() {
+        let snapshot = ForegroundCoverageSnapshot(
+            app: ForegroundCoverageAppState(
+                pid: 200,
+                bundleID: "com.example.editor",
+                isFinder: false
+            ),
+            targetDisplayIDs: targetIDs,
+            axProbe: .uncertain,
+            cgProbe: .uncertain
+        )
+
+        let suspended = ForegroundCoverageEngine.suspendedDisplayIDs(
+            mode: .preciseWindowCoverage,
+            snapshot: snapshot
+        )
+
+        XCTAssertEqual(suspended, targetIDs)
+    }
+
+    func testPreciseModeFallsBackWhenAXPermissionIsUnavailableAndCGIsUncertain() {
+        let snapshot = ForegroundCoverageSnapshot(
+            app: ForegroundCoverageAppState(
+                pid: 250,
+                bundleID: "com.example.mail",
+                isFinder: false
+            ),
+            targetDisplayIDs: targetIDs,
+            axProbe: .uncertain,
+            cgProbe: .uncertain
+        )
+
+        let suspended = ForegroundCoverageEngine.suspendedDisplayIDs(
+            mode: .preciseWindowCoverage,
+            snapshot: snapshot
+        )
+
+        XCTAssertEqual(suspended, targetIDs)
+    }
+
+    func testPreciseModeChecksCGWhenAXIsClear() {
+        let snapshot = ForegroundCoverageSnapshot(
+            app: ForegroundCoverageAppState(
+                pid: 300,
+                bundleID: "com.example.browser",
+                isFinder: false
+            ),
+            targetDisplayIDs: targetIDs,
+            axProbe: .clear,
+            cgProbe: .covered(["main"])
+        )
+
+        let suspended = ForegroundCoverageEngine.suspendedDisplayIDs(
+            mode: .preciseWindowCoverage,
+            snapshot: snapshot
+        )
+
+        XCTAssertEqual(suspended, ["main"])
+    }
+
+    func testPreciseModeTrustsAXClearOverUncertainCG() {
+        let snapshot = ForegroundCoverageSnapshot(
+            app: ForegroundCoverageAppState(
+                pid: 400,
+                bundleID: "com.example.notes",
+                isFinder: false
+            ),
+            targetDisplayIDs: targetIDs,
+            axProbe: .clear,
+            cgProbe: .uncertain
+        )
+
+        let suspended = ForegroundCoverageEngine.suspendedDisplayIDs(
+            mode: .preciseWindowCoverage,
+            snapshot: snapshot
+        )
+
+        XCTAssertTrue(suspended.isEmpty)
+    }
+}

--- a/Tests/LiveWallpaperTests/ForegroundCoverageGeometryTests.swift
+++ b/Tests/LiveWallpaperTests/ForegroundCoverageGeometryTests.swift
@@ -1,0 +1,116 @@
+import CoreGraphics
+import XCTest
+@testable import LiveWallpaper
+
+final class ForegroundCoverageGeometryTests: XCTestCase {
+    func testFullScreenWindowCoversOnlyIntersectingDisplay() {
+        let displays = [
+            ForegroundCoverageDisplay(
+                id: "left",
+                frame: CGRect(x: 0, y: 0, width: 1000, height: 800)
+            ),
+            ForegroundCoverageDisplay(
+                id: "right",
+                frame: CGRect(x: 1000, y: 0, width: 1000, height: 800)
+            )
+        ]
+        let windows = [
+            ForegroundCoverageWindow(
+                bounds: CGRect(x: 1000, y: 0, width: 1000, height: 800)
+            )
+        ]
+
+        let covered = ForegroundCoverageGeometry.coveredDisplayIDs(
+            by: windows,
+            displays: displays,
+            coverageThreshold: 0.9
+        )
+
+        XCTAssertEqual(covered, ["right"])
+    }
+
+    func testWindowCrossingDisplaysRequiresThresholdPerDisplay() {
+        let displays = [
+            ForegroundCoverageDisplay(
+                id: "left",
+                frame: CGRect(x: 0, y: 0, width: 1000, height: 800)
+            ),
+            ForegroundCoverageDisplay(
+                id: "right",
+                frame: CGRect(x: 1000, y: 0, width: 1000, height: 800)
+            )
+        ]
+        let windows = [
+            ForegroundCoverageWindow(
+                bounds: CGRect(x: 100, y: 0, width: 1400, height: 800)
+            )
+        ]
+
+        let covered = ForegroundCoverageGeometry.coveredDisplayIDs(
+            by: windows,
+            displays: displays,
+            coverageThreshold: 0.9
+        )
+
+        XCTAssertEqual(covered, ["left"])
+    }
+
+    func testDisplayCanMatchAlternateCoordinateFrame() {
+        let displays = [
+            ForegroundCoverageDisplay(
+                id: "main",
+                frames: [
+                    CGRect(x: 0, y: 0, width: 1000, height: 800),
+                    CGRect(x: 0, y: -800, width: 1000, height: 800)
+                ]
+            )
+        ]
+        let windows = [
+            ForegroundCoverageWindow(
+                bounds: CGRect(x: 0, y: -800, width: 1000, height: 800)
+            )
+        ]
+
+        let covered = ForegroundCoverageGeometry.coveredDisplayIDs(
+            by: windows,
+            displays: displays,
+            coverageThreshold: 0.9
+        )
+
+        XCTAssertEqual(covered, ["main"])
+    }
+
+    func testSmallTransparentNegativeLayerAndMiniaturizedWindowsAreIgnored() {
+        let displays = [
+            ForegroundCoverageDisplay(
+                id: "main",
+                frame: CGRect(x: 0, y: 0, width: 1000, height: 800)
+            )
+        ]
+        let windows = [
+            ForegroundCoverageWindow(
+                bounds: CGRect(x: 0, y: 0, width: 1000, height: 800),
+                alpha: 0
+            ),
+            ForegroundCoverageWindow(
+                bounds: CGRect(x: 0, y: 0, width: 1000, height: 800),
+                layer: -1
+            ),
+            ForegroundCoverageWindow(
+                bounds: CGRect(x: 0, y: 0, width: 100, height: 100)
+            ),
+            ForegroundCoverageWindow(
+                bounds: CGRect(x: 0, y: 0, width: 1000, height: 800),
+                isMiniaturized: true
+            )
+        ]
+
+        let covered = ForegroundCoverageGeometry.coveredDisplayIDs(
+            by: windows,
+            displays: displays,
+            coverageThreshold: 0.9
+        )
+
+        XCTAssertTrue(covered.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- 壁紙の自動停止判定をCoverageEngineへ分離し、Spaces切り替え後の前面アプリ検知とAX/CGフォールバックを安定化
- アクセシビリティ権限状態を単一ソース化し、許可後に警告表示が残らないよう改善
- 共有/サムネイル周りの既存ブランチ変更も含む

## Test plan
- `swift build`
- `swift test`


Made with [Cursor](https://cursor.com)